### PR TITLE
mnist/load: update mnist source file names

### DIFF
--- a/mnist/load.py
+++ b/mnist/load.py
@@ -12,19 +12,19 @@ from lib.data_utils import shuffle
 from lib.config import data_dir
 
 def mnist():
-    fd = open(os.path.join(data_dir,'train-images.idx3-ubyte'))
+    fd = open(os.path.join(data_dir,'train-images-idx3-ubyte'))
     loaded = np.fromfile(file=fd,dtype=np.uint8)
     trX = loaded[16:].reshape((60000,28*28)).astype(float)
 
-    fd = open(os.path.join(data_dir,'train-labels.idx1-ubyte'))
+    fd = open(os.path.join(data_dir,'train-labels-idx1-ubyte'))
     loaded = np.fromfile(file=fd,dtype=np.uint8)
     trY = loaded[8:].reshape((60000))
 
-    fd = open(os.path.join(data_dir,'t10k-images.idx3-ubyte'))
+    fd = open(os.path.join(data_dir,'t10k-images-idx3-ubyte'))
     loaded = np.fromfile(file=fd,dtype=np.uint8)
     teX = loaded[16:].reshape((10000,28*28)).astype(float)
 
-    fd = open(os.path.join(data_dir,'t10k-labels.idx1-ubyte'))
+    fd = open(os.path.join(data_dir,'t10k-labels-idx1-ubyte'))
     loaded = np.fromfile(file=fd,dtype=np.uint8)
     teY = loaded[8:].reshape((10000))
     


### PR DESCRIPTION
Unless I'm missing something, I think there was a typo in the mnist file names. eg: they didn't match the names in [the Theano tutorial](https://github.com/Newmu/Theano-Tutorials/blob/49de4c52f45ab7b05cea3dbad039270f816be70c/load.py#L16-L28).
